### PR TITLE
Added cffi dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'sklearn',
         'six',
         'jsonpickle',
+        'cffi'
     ],
     extras_require={
         'docs': ['numpydoc']


### PR DESCRIPTION
The package does not require 'cffi' to install, but will throw an `ImportError` if `cffi` is not available, so I added it as a dependency.