### PR TITLE
Populate file_metadata.duration on load_jam_audio

### DIFF
--- a/muda/core.py
+++ b/muda/core.py
@@ -79,6 +79,12 @@ def load_jam_audio(jam_in, audio_file, **kwargs):
     jam : jams.JAMS
         A jams object with audio data in the top-level sandbox
 
+    Notes
+    -----
+    This operation can modify the `file_metadata.duration` field of `jam_in`:
+    If it is not currently set, it will be populated with the duration of the
+    audio file.
+
     See Also
     --------
     jams.load
@@ -91,6 +97,9 @@ def load_jam_audio(jam_in, audio_file, **kwargs):
         jam = jams.load(jam_in)
 
     y, sr = librosa.load(audio_file, **kwargs)
+
+    if jam.file_metadata.duration is None:
+        jam.file_metadata.duration = librosa.get_duration(y=y, sr=sr)
 
     return jam_pack(jam, _audio=dict(y=y, sr=sr))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -43,6 +43,9 @@ def test_load_jam_audio():
         eq_(jam.file_metadata.duration,
             librosa.get_duration(**jam.sandbox.muda._audio))
 
+    # Add an empty jams test for missing duration
+    yield __test, jams.JAMS(), 'data/fixture.wav'
+
     yield __test, 'data/fixture.jams', 'data/fixture.wav'
 
     yield __test, jams.load('data/fixture.jams'), 'data/fixture.wav'


### PR DESCRIPTION
This should fix #34

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/muda/35)
<!-- Reviewable:end -->
