### PR TITLE
Force jam.sandbox.muda as jams.Sandbox

### DIFF
--- a/muda/core.py
+++ b/muda/core.py
@@ -14,11 +14,12 @@ from .version import version
 
 __all__ = ['load_jam_audio', 'save', 'jam_pack', 'serialize', 'deserialize']
 
+
 def jam_pack(jam, **kwargs):
     '''Pack data into a jams sandbox.
 
     If not already present, this creates a `muda` field within `jam.sandbox`,
-    along with `history`, `state`, and version arrays which are populated by 
+    along with `history`, `state`, and version arrays which are populated by
     deformation objects.
 
     Any additional fields can be added to the `muda` sandbox by supplying
@@ -47,12 +48,17 @@ def jam_pack(jam, **kwargs):
     '''
 
     if not hasattr(jam.sandbox, 'muda'):
+        # If there's no mudabox, create one
         jam.sandbox.muda = jams.Sandbox(history=[],
                                         state=[],
                                         version=dict(muda=version,
                                                      librosa=librosa.__version__,
                                                      jams=jams.__version__,
                                                      pysoundfile=psf.__version__))
+
+    elif not isinstance(jam.sandbox.muda, jams.Sandbox):
+        # If there is a muda entry, but it's not a sandbox, coerce it
+        jam.sandbox.muda = jams.Sandbox(**jam.sandbox.muda)
 
     jam.sandbox.muda.update(**kwargs)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,7 @@ import librosa
 
 import tempfile
 import os
+import six
 
 from nose.tools import eq_, raises
 
@@ -102,3 +103,14 @@ def test_serialize_pipeline():
     eq_(P_orig.get_params(), P_new.get_params())
 
     assert P_orig is not P_new
+
+
+def test_reload_jampack():
+
+    # This test is to address #42, where mudaboxes reload as dict
+    # instead of Sandbox
+    jam = muda.load_jam_audio('data/fixture.jams', 'data/fixture.wav')
+
+    jam2 = muda.load_jam_audio(six.StringIO(jam.dumps()), 'data/fixture.wav')
+    assert isinstance(jam.sandbox.muda, jams.Sandbox)
+    assert isinstance(jam2.sandbox.muda, jams.Sandbox)


### PR DESCRIPTION
This resolves #42, where mudabox gets deserialized as `dict` instead of `jams.Sandbox`.

The solution here is to coerce the type within `muda.jam_pack`.

An alternate solution would be to relax the mudabox type to support `dict`.  However, this would complicate the logic of serialization, since we use jams's underscore-prefix suppression to omit `_audio` objects on save.

For now, I think this hack is sufficient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/muda/44)
<!-- Reviewable:end -->
