### PR TITLE
Multiple values for PitchShift and TimeStretch deformers

### DIFF
--- a/muda/deformers/pitch.py
+++ b/muda/deformers/pitch.py
@@ -120,7 +120,7 @@ class PitchShift(AbstractPitchShift):
 
     Attributes
     ----------
-    n_semitones : float
+    n_semitones : float or list of float
         The number of semitones to transpose the signal.
         Can be positive, negative, integral, or fractional.
 
@@ -137,12 +137,13 @@ class PitchShift(AbstractPitchShift):
 
     def __init__(self, n_semitones=1):
         AbstractPitchShift.__init__(self)
-        self.n_semitones = float(n_semitones)
+        self.n_semitones = np.atleast_1d(n_semitones).flatten()
 
     def states(self, jam):
         for state in AbstractPitchShift.states(self, jam):
-            state['n_semitones'] = self.n_semitones
-            yield state
+            for semitones in self.n_semitones:
+                state['n_semitones'] = semitones
+                yield state
 
 
 class RandomPitchShift(AbstractPitchShift):

--- a/muda/deformers/pitch.py
+++ b/muda/deformers/pitch.py
@@ -137,7 +137,7 @@ class PitchShift(AbstractPitchShift):
 
     def __init__(self, n_semitones=1):
         AbstractPitchShift.__init__(self)
-        self.n_semitones = np.atleast_1d(n_semitones).flatten()
+        self.n_semitones = np.atleast_1d(n_semitones).flatten().tolist()
 
     def states(self, jam):
         for state in AbstractPitchShift.states(self, jam):

--- a/muda/deformers/time.py
+++ b/muda/deformers/time.py
@@ -101,6 +101,7 @@ class TimeStretch(AbstractTimeStretch):
         self.rate = np.atleast_1d(rate).flatten()
         if np.any(self.rate <= 0):
             raise ValueError('rate parameter must be strictly positive.')
+        self.rate = self.rate.tolist()
 
     def states(self, jam):
         for rate in self.rate:

--- a/muda/deformers/time.py
+++ b/muda/deformers/time.py
@@ -79,7 +79,7 @@ class TimeStretch(AbstractTimeStretch):
 
     Attributes
     ----------
-    rate : float > 0
+    rate : float or list of floats, strictly positive
         The rate at which to speedup the audio.
         - rate > 1 speeds up,
         - rate < 1 slows down.
@@ -98,12 +98,13 @@ class TimeStretch(AbstractTimeStretch):
         '''Time stretching'''
         AbstractTimeStretch.__init__(self)
 
-        self.rate = float(rate)
-        if rate <= 0:
+        self.rate = np.atleast_1d(rate).flatten()
+        if np.any(self.rate <= 0):
             raise ValueError('rate parameter must be strictly positive.')
 
     def states(self, jam):
-        yield dict(rate=self.rate)
+        for rate in self.rate:
+            yield dict(rate=rate)
 
 
 class LogspaceTimeStretch(AbstractTimeStretch):
@@ -126,7 +127,7 @@ class LogspaceTimeStretch(AbstractTimeStretch):
     n_samples : int > 0
         Number of deformations to generate
 
-    lower : float 
+    lower : float
     upper : float > lower
         Minimum and maximum bounds on the stretch parameters
 
@@ -156,6 +157,7 @@ class LogspaceTimeStretch(AbstractTimeStretch):
 
         for rate in rates:
             yield dict(rate=rate)
+
 
 class RandomTimeStretch(AbstractTimeStretch):
     '''Random time stretching

--- a/tests/test_deformers.py
+++ b/tests/test_deformers.py
@@ -426,7 +426,7 @@ def test_pipeline(jam_fixture):
         __test_deformer_history(D1, jam_new.sandbox.muda.history[0])
         __test_deformer_history(D2, jam_new.sandbox.muda.history[-1])
 
-        __test_time(jam_orig, jam_new, D1.rate * D2.rate)
+        __test_time(jam_orig, jam_new, D1.rate[0] * D2.rate[0])
 
 
 @pytest.mark.xfail(raises=ValueError)

--- a/tests/test_deformers.py
+++ b/tests/test_deformers.py
@@ -74,7 +74,7 @@ def __test_deformer_history(deformer, history):
     d_trans['__class__'] == params['__class__'].__name__
 
 
-@pytest.mark.parametrize('rate', [0.5, 1.0, 2.0,
+@pytest.mark.parametrize('rate', [0.5, 1.0, 2.0, [1.0, 1.5],
                                   pytest.mark.xfail(-1, raises=ValueError),
                                   pytest.mark.xfail(-0.5, raises=ValueError),
                                   pytest.mark.xfail(0.0, raises=ValueError)])
@@ -94,7 +94,10 @@ def test_timestretch(rate, jam_fixture):
 
         d_state = jam_new.sandbox.muda.history[-1]['state']
         d_rate = d_state['rate']
-        ap_(rate, d_rate)
+        if isinstance(rate, list):
+            assert d_rate in rate
+        else:
+            assert d_rate == rate
 
         __test_time(jam_orig, jam_new, d_rate)
 
@@ -256,7 +259,7 @@ def __test_pitch(jam_orig, jam_new, n_semitones, tuning):
 
 
 @pytest.mark.parametrize('n_semitones',
-                         [-2, -1, -0.5, -0.25, 0, 0.25, 1.0, 1.5])
+                         [-2, -1, -0.5, -0.25, 0, 0.25, 1.0, 1.5, [-1, 1]])
 def test_pitchshift(n_semitones, jam_fixture):
     np.random.seed(0)
     D = muda.deformers.PitchShift(n_semitones=n_semitones)
@@ -274,7 +277,11 @@ def test_pitchshift(n_semitones, jam_fixture):
         d_state = jam_new.sandbox.muda.history[-1]['state']
         d_tones = d_state['n_semitones']
         tuning = d_state['tuning']
-        ap_(n_semitones, d_tones)
+        if isinstance(n_semitones, list):
+            assert d_tones in n_semitones
+        else:
+            assert d_tones == n_semitones
+
         __test_pitch(jam_orig, jam_new, d_tones, tuning)
 
 

--- a/tests/test_deformers.py
+++ b/tests/test_deformers.py
@@ -101,6 +101,10 @@ def test_timestretch(rate, jam_fixture):
 
         __test_time(jam_orig, jam_new, d_rate)
 
+    # Serialization test
+    D2 = muda.deserialize(muda.serialize(D))
+    assert D.get_params() == D2.get_params()
+
 
 @pytest.fixture(params=[1, 3, 5,
                         pytest.mark.xfail(-3, raises=ValueError),
@@ -138,6 +142,9 @@ def test_log_timestretch(n_samples, lower, upper, jam_fixture):
         n_out += 1
 
     assert n_samples == n_out
+    # Serialization test
+    D2 = muda.deserialize(muda.serialize(D))
+    assert D.get_params() == D2.get_params()
 
 
 @pytest.mark.parametrize('scale',
@@ -167,6 +174,9 @@ def test_random_timestretch(n_samples, scale, jam_fixture):
         n_out += 1
 
     assert n_samples == n_out
+    # Serialization test
+    D2 = muda.deserialize(muda.serialize(D))
+    assert D.get_params() == D2.get_params()
 
 
 @pytest.fixture(scope='module',
@@ -196,6 +206,9 @@ def test_bypass(D_simple, jam_fixture):
 
         # Verify that the state and history objects are intact
         __test_deformer_history(D_simple, jam_new.sandbox.muda.history[-1])
+    # Serialization test
+    D2 = muda.deserialize(muda.serialize(D))
+    assert D.get_params() == D2.get_params()
 
 
 def pstrip(x):
@@ -283,6 +296,9 @@ def test_pitchshift(n_semitones, jam_fixture):
             assert d_tones == n_semitones
 
         __test_pitch(jam_orig, jam_new, d_tones, tuning)
+    # Serialization test
+    D2 = muda.deserialize(muda.serialize(D))
+    assert D.get_params() == D2.get_params()
 
 
 @pytest.mark.parametrize('sigma',
@@ -311,6 +327,9 @@ def test_random_pitchshift(n_samples, sigma, jam_fixture):
         n_out += 1
 
     assert n_out == n_samples
+    # Serialization test
+    D2 = muda.deserialize(muda.serialize(D))
+    assert D.get_params() == D2.get_params()
 
 
 @pytest.mark.parametrize('lower, upper',
@@ -342,6 +361,9 @@ def test_linear_pitchshift(n_samples, lower, upper, jam_fixture):
         n_out += 1
 
     assert n_out == n_samples
+    # Serialization test
+    D2 = muda.deserialize(muda.serialize(D))
+    assert D.get_params() == D2.get_params()
 
 
 def __test_effect(jam_orig, jam_new):
@@ -370,6 +392,9 @@ def test_drc(preset, jam_fixture):
                                jam_new.sandbox.muda['_audio']['y'])
 
         __test_effect(jam_orig, jam_new)
+    # Serialization test
+    D2 = muda.deserialize(muda.serialize(D))
+    assert D.get_params() == D2.get_params()
 
 
 @pytest.mark.parametrize('noise', ['tests/data/noise_sample.ogg',
@@ -402,6 +427,9 @@ def test_background(noise, n_samples, weight_min, weight_max, jam_fixture):
         n_out += 1
 
     assert n_out == n_samples
+    # Serialization test
+    D2 = muda.deserialize(muda.serialize(D))
+    assert D.get_params() == D2.get_params()
 
 
 @pytest.mark.xfail(raises=RuntimeError)


### PR DESCRIPTION
This PR implements #41.  PitchShift can now accept an array of shift values, in addition to a single scalar.  Similarly for TimeStretch.