### PR TITLE
added deformation union

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -23,3 +23,7 @@ Classes
 .. autoclass:: Pipeline
     :members:
     :no-undoc-members:
+
+.. autoclass:: Union
+    :members:
+    :no-undoc-members:

--- a/muda/base.py
+++ b/muda/base.py
@@ -303,7 +303,7 @@ class Union(object):
                                            offset=len(class_name),),)
 
     def __serial_transform(self, jam, steps):
-        '''A serial transformation pipeline'''
+        '''A serial transformation union'''
         # This uses the round-robin itertools recipe
 
         if six.PY2:
@@ -314,9 +314,6 @@ class Union(object):
         pending = len(steps)
         nexts = itertools.cycle(getattr(iter(D.transform(jam)), attr)
                                 for (name, D) in steps)
-
-        if not pending:
-            yield jam
 
         while pending:
             try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -97,16 +97,6 @@ def test_save(jam_in, audio_file):
     assert jam2.file_metadata.duration == duration
 
 
-def test_serialize_deformer():
-
-    D = muda.deformers.LogspaceTimeStretch()
-    D_ser = muda.serialize(D)
-    D2 = muda.deserialize(D_ser)
-
-    assert D is not D2
-    assert D.get_params() == D2.get_params()
-
-
 def test_serialize_pipeline():
 
     D1 = muda.deformers.LogspaceTimeStretch()
@@ -119,6 +109,20 @@ def test_serialize_pipeline():
 
     assert P_orig is not P_new
     assert P_orig.get_params() == P_new.get_params()
+
+
+def test_serialize_union():
+
+    D1 = muda.deformers.LogspaceTimeStretch()
+    D2 = muda.deformers.LogspaceTimeStretch()
+    U_orig = muda.Union([('stretch_1', D1),
+                         ('stretch_2', D2)])
+    U_ser = muda.serialize(U_orig)
+
+    U_new = muda.deserialize(U_ser)
+
+    assert U_orig is not U_new
+    assert U_orig.get_params() == U_new.get_params()
 
 
 def test_reload_jampack(jam_in, audio_file):


### PR DESCRIPTION
Implements #50.

The deformation union works just like the pipeline, except that deformations are processed in parallel (independently) rather than in serial (dependently).