### PR TITLE
Bugfix #59: `BackgroundNoise` fails if `len(soundf)==n_target`

### DIFF
--- a/muda/deformers/background.py
+++ b/muda/deformers/background.py
@@ -45,7 +45,7 @@ def sample_clip_indices(filename, n_samples, sr):
 
         # Draw a starting point at random in the background waveform
         start = np.random.randint(0, 1 + len(soundf) - n_target)
-        stop = start + target_length
+        stop = start + n_target
 
         return start, stop
 

--- a/muda/deformers/background.py
+++ b/muda/deformers/background.py
@@ -35,12 +35,17 @@ def sample_clip_indices(filename, n_samples, sr):
     '''
 
     with psf.SoundFile(str(filename), mode='r') as soundf:
-
+        # Measure required length of fragment
         n_target = int(np.ceil(n_samples * soundf.samplerate / float(sr)))
 
-        # Draw a random clip
-        start = np.random.randint(0, len(soundf) - n_target)
-        stop = start + n_target
+        # Raise exception if source is too short
+        if len(soundf) < n_target:
+            raise RuntimeError('Source {} (length={})'.format(filename, len(soundf)) +
+                ' must be at least the length of the input ({})'.format(n_target))
+
+        # Draw a starting point at random in the background waveform
+        start = np.random.randint(0, 1 + len(soundf) - n_target)
+        stop = start + target_length
 
         return start, stop
 

--- a/tests/test_deformers.py
+++ b/tests/test_deformers.py
@@ -458,6 +458,14 @@ def test_background_no_file():
     muda.deformers.BackgroundNoise(files='does-not-exist.ogg', n_samples=1)
 
 
+@pytest.mark.xfail(raises=RuntimeError)
+def test_background_short_file():
+    D = muda.deformers.BackgroundNoise(files='tests/data/fixture.wav')
+    jam_orig = muda.load_jam_audio('tests/data/fixture.jams',
+                                   'tests/data/noise_sample.ogg')
+    jam_new = next(D.transform(jam_orig))
+
+
 def test_pipeline(jam_fixture):
     D1 = muda.deformers.TimeStretch(rate=2.0)
     D2 = muda.deformers.TimeStretch(rate=1.5)


### PR DESCRIPTION
Fixes #59.

If `len(soundf) < n_target`, raises a `RuntimeError` which prints the
faulty values of `filename`, `len(soundf)` and `n_target`.

This is a breaking change, because the maximal value for the random
integer `start` is increased by 1.

Milestone: v0.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/muda/60)
<!-- Reviewable:end -->
