### PR TITLE
load audio with no annotation

### DIFF
--- a/muda/core.py
+++ b/muda/core.py
@@ -74,9 +74,11 @@ def load_jam_audio(jam_in, audio_file,
 
     Parameters
     ----------
-    jam_in : str, file descriptor, or jams.JAMS
+    jam_in : str, file descriptor, jams.JAMS, or None
         JAMS filename, open file-descriptor, or object to load.
         See ``jams.load`` for acceptable formats.
+
+        If `None` is provided, an empty JAMS object is constructed.
 
     audio_file : str
         Audio filename to load
@@ -104,10 +106,26 @@ def load_jam_audio(jam_in, audio_file,
     --------
     jams.load
     librosa.core.load
+
+
+    Examples
+    --------
+
+    Load a JAMS object and audio from disk
+
+    >>> jam = muda.load_jam_audio('my_file.jams', 'my_file.wav')
+
+
+    Load an audio file with no jams annotation
+
+    >>> jam = muda.load_jam_audio(None, 'my_file.wav')
+
     '''
 
     if isinstance(jam_in, jams.JAMS):
         jam = jam_in
+    elif jam_in is None:
+        jam = jams.JAMS()
     else:
         jam = jams.load(jam_in, validate=validate, strict=strict, fmt=fmt)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -43,11 +43,12 @@ def jam_in():
     return 'tests/data/fixture.jams'
 
 
-@pytest.fixture(params=[0, 1, 2, 3],
+@pytest.fixture(params=[0, 1, 2, 3, 4],
                 ids=['JAMS()',
                      'fixture.jams',
                      "JAMS('fixture.jams')",
-                     'fdesc'])
+                     'fdesc',
+                     'None'])
 def jam_loader(request):
     if request.param == 0:
         yield jams.JAMS()
@@ -58,9 +59,11 @@ def jam_loader(request):
     elif request.param == 2:
         yield jams.load('tests/data/fixture.jams')
 
-    else:
+    elif request.param == 3:
         with open('tests/data/fixture.jams', 'r') as fdesc:
             yield fdesc
+    else:
+        yield None
 
 
 @pytest.mark.parametrize('validate', [False, True])


### PR DESCRIPTION
Fixes #63 

This PR adds support for muda on unannotated data.  The fix automates the process described in #63, where an empty jams object is constructed on load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/muda/69)
<!-- Reviewable:end -->
