### PR TITLE
Random seeds

### DIFF
--- a/muda/deformers/pitch.py
+++ b/muda/deformers/pitch.py
@@ -10,7 +10,7 @@ import numpy as np
 import six
 from copy import deepcopy
 
-from ..base import BaseTransformer
+from ..base import BaseTransformer, _get_rng
 
 __all__ = ['PitchShift', 'RandomPitchShift', 'LinearPitchShift']
 
@@ -194,6 +194,13 @@ class RandomPitchShift(AbstractPitchShift):
         The parameters of the normal distribution for sampling
         pitch shifts
 
+    rng : None, int, or np.random.RandomState
+        The random number generator state.
+
+        If `None`, then `np.random` is used.
+
+        If `int`, then `rng` becomes the seed for the random state.
+
     See Also
     --------
     PitchShift
@@ -204,7 +211,7 @@ class RandomPitchShift(AbstractPitchShift):
     >>> # 5 random shifts with unit variance and mean of 1 semitone
     >>> D = muda.deformers.PitchShift(n_samples=5, mean=1.0, sigma=1)
     '''
-    def __init__(self, n_samples=3, mean=0.0, sigma=1.0):
+    def __init__(self, n_samples=3, mean=0.0, sigma=1.0, rng=None):
         AbstractPitchShift.__init__(self)
 
         if sigma <= 0:
@@ -216,14 +223,15 @@ class RandomPitchShift(AbstractPitchShift):
         self.n_samples = n_samples
         self.mean = float(mean)
         self.sigma = float(sigma)
+        self.rng = _get_rng(rng)
 
     def states(self, jam):
         # Sample the deformation
         for state in AbstractPitchShift.states(self, jam):
             for _ in range(self.n_samples):
-                state['n_semitones'] = np.random.normal(loc=self.mean,
-                                                        scale=self.sigma,
-                                                        size=None)
+                state['n_semitones'] = self.rng.normal(loc=self.mean,
+                                                       scale=self.sigma,
+                                                       size=None)
                 yield state
 
 

--- a/muda/deformers/time.py
+++ b/muda/deformers/time.py
@@ -5,9 +5,8 @@
 
 import pyrubberband as pyrb
 import numpy as np
-import pandas as pd
 
-from ..base import BaseTransformer
+from ..base import BaseTransformer, _get_rng
 
 __all__ = ['TimeStretch',
            'RandomTimeStretch',
@@ -184,13 +183,20 @@ class RandomTimeStretch(AbstractTimeStretch):
         Parameters of a log-normal distribution from which
         rate parameters are sampled.
 
+    rng : None, int, or np.random.RandomState
+        The random number generator state.
+
+        If `None`, then `np.random` is used.
+
+        If `int`, then `rng` becomes the seed for the random state.
+
     See Also
     --------
     TimeStretch
     LogspaceTimeStretch
     numpy.random.lognormal
     '''
-    def __init__(self, n_samples=3, location=0.0, scale=1.0e-1):
+    def __init__(self, n_samples=3, location=0.0, scale=1.0e-1, rng=None):
 
         AbstractTimeStretch.__init__(self)
 
@@ -203,11 +209,12 @@ class RandomTimeStretch(AbstractTimeStretch):
         self.n_samples = n_samples
         self.location = location
         self.scale = scale
+        self.rng = _get_rng(rng)
 
     def states(self, jam):
-        rates = np.random.lognormal(mean=self.location,
-                                    sigma=self.scale,
-                                    size=self.n_samples)
+        rates = self.rng.lognormal(mean=self.location,
+                                   sigma=self.scale,
+                                   size=self.n_samples)
 
         for rate in rates:
             yield dict(rate=rate)


### PR DESCRIPTION
This PR fixes #31 by standardizing the ability to seed random number generators.

Note that this breaks object compatibility from the 0.2 series, so old deformers will need to be reconstructed moving forward to ensure that they have randomstate objects.

There are a bunch of minor compatibility fixes rolled into this one as well, mainly to do with some legacy python compatibility issues and deprecations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/muda/70)
<!-- Reviewable:end -->
