### PR TITLE
Use soundfile for all IO

### DIFF
--- a/muda/deformers/sox.py
+++ b/muda/deformers/sox.py
@@ -50,7 +50,7 @@ def __sox(y, sr, *args):
     os.close(fdesc)
 
     # Dump the audio
-    librosa.output.write_wav(infile, y, sr)
+    psf.write(infile, y, sr)
 
     try:
         arguments = ["sox", infile, outfile, "-q"]
@@ -146,3 +146,4 @@ class DynamicRangeCompression(BaseTransformer):
         mudabox._audio["y"] = drc(
             mudabox._audio["y"], mudabox._audio["sr"], state["preset"]
         )
+


### PR DESCRIPTION
This PR fixes #76 by switching all IO to use `pysoundfile` instead of librosa.  We had previously switched most of the code, but missed one call in the sox-based deformers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/muda/77)
<!-- Reviewable:end -->
