### PR TITLE
fixed unicode compatibility issue in transpose

### DIFF
--- a/muda/deformers/pitch.py
+++ b/muda/deformers/pitch.py
@@ -44,7 +44,7 @@ def transpose(label, n_semitones):
     note = match.group("note")
 
     new_note = librosa.midi_to_note(
-        librosa.note_to_midi(note) + n_semitones, octave=False
+        librosa.note_to_midi(note) + n_semitones, octave=False, unicode=False
     )
 
     return new_note + match.group("mod")

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     keywords='audio music sound',
     license='ISC',
     install_requires=[
-        'librosa>=0.4',
+        'librosa>=0.8',
         'pyrubberband>=0.1',
         'pandas',
         'jams>=0.3.0',


### PR DESCRIPTION
With Librosa 0.8.0, the default `librosa.midi_to_note` outputs a unicode string for sharps and flats. This behavior breaks with JAMS schema.